### PR TITLE
Utilisation d'un shared_ptr pour les pixels

### DIFF
--- a/src/component/Sprite.hpp
+++ b/src/component/Sprite.hpp
@@ -23,7 +23,7 @@ namespace arcade {
 namespace component {
 
     struct Sprite : public IComponent {
-        std::vector<Color> pixels;
+        std::shared_ptr<std::vector<Color>> pixels;
         size_t width;
         size_t height;
     };


### PR DESCRIPTION
Afin d'éviter une copie des données lors de la manipulation de la structure