### PR TITLE
Changer Sprite en ISprite

### DIFF
--- a/src/component/Sprite.hpp
+++ b/src/component/Sprite.hpp
@@ -22,10 +22,9 @@ struct Color {
 
 namespace component {
 
-    struct Sprite : public IComponent {
-        std::shared_ptr<std::vector<Color>> pixels;
-        size_t width;
-        size_t height;
+    class ISprite : public IComponent {
+        virtual ~ISprite() = default;
+        virtual void draw() = 0;
     };
 
 }


### PR DESCRIPTION
Je propose que l'on renomme Sprite en ISprite en mettant la fonction draw qui dessinera ce composant au lieu d'avoir des variables. ça permettra de ne pas avoir de problème pour ceux veulent dessiner des pixels ou ceux qui veulent charger une image pour la dessiner